### PR TITLE
Scrolling aparecendo no <iframe> do tcpe

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -103,6 +103,8 @@
     embed.setAttribute('src', content);
     embed.setAttribute('width', width);
     embed.setAttribute('height', height);
+    embed.setAttribute('scrolling', 'no');
+    embed.setAttribute('frameborder', '0');
 
     document.body.insertBefore(embed, document.body.firstElementChild);
 


### PR DESCRIPTION
Quando o <iframe> externo é exatamente da altura do info barras de rolagem aparecem no <iframe> do TPCE aparecem.

Adicionados atributos: scrolling="no" e frameborder="0" ao <iframe> do TPCE.
